### PR TITLE
feat: drawing layers (pen/arrow/circle/rect, textures, write-on animation)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -116,7 +116,7 @@ export default function App() {
   // Auto-save on timeline changes (debounced 3s)
   useEffect(() => {
     const unsub = storeApi.subscribe((state, prevState) => {
-      // Only auto-save when meaningful data changes
+      // Only react when meaningful data changes
       if (
         state.clips === prevState.clips &&
         state.tracks === prevState.tracks &&
@@ -124,14 +124,18 @@ export default function App() {
         state.settings === prevState.settings
       ) return;
 
+      // Mark dirty immediately so the * indicator appears as soon as edits happen
+      storeApi.getState().markProjectDirty();
+
       if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
       autoSaveTimerRef.current = setTimeout(() => {
-        const current = storeApi.getState();
-        autoSaveLocal(current);
-        current.markProjectDirty();
+        autoSaveLocal(storeApi.getState());
       }, 3000);
     });
-    return unsub;
+    return () => {
+      unsub();
+      if (autoSaveTimerRef.current) clearTimeout(autoSaveTimerRef.current);
+    };
   }, [storeApi]);
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -93,6 +93,7 @@ export default function App() {
       tracks: deserialized.tracks.length > 0 ? deserialized.tracks : currentState.tracks,
       clips: deserialized.clips,
       textOverlays: deserialized.textOverlays,
+      drawingOverlays: deserialized.drawingOverlays,
       transcripts: deserialized.transcripts,
       settings: { ...currentState.settings, ...deserialized.settings },
       currentProjectId: saved.projectId,
@@ -121,6 +122,7 @@ export default function App() {
         state.clips === prevState.clips &&
         state.tracks === prevState.tracks &&
         state.textOverlays === prevState.textOverlays &&
+        state.drawingOverlays === prevState.drawingOverlays &&
         state.settings === prevState.settings
       ) return;
 

--- a/src/components/settings/DrawingToolPanel.tsx
+++ b/src/components/settings/DrawingToolPanel.tsx
@@ -1,0 +1,141 @@
+import { Pen, ArrowUpRight, Circle, Square } from 'lucide-react';
+import { useTimelineStore } from '../../store/timeline';
+import type { DrawingTexture, DrawingToolType } from '../../types';
+
+const TOOLS: { type: DrawingToolType; icon: typeof Pen; label: string }[] = [
+  { type: 'pen', icon: Pen, label: 'Pen' },
+  { type: 'arrow', icon: ArrowUpRight, label: 'Arrow' },
+  { type: 'circle', icon: Circle, label: 'Circle' },
+  { type: 'rectangle', icon: Square, label: 'Rect' },
+];
+
+const TEXTURES: { type: DrawingTexture; label: string }[] = [
+  { type: 'solid', label: 'Solid' },
+  { type: 'marker', label: 'Marker' },
+  { type: 'chalk', label: 'Chalk' },
+];
+
+export function DrawingToolPanel() {
+  const activeDrawingTool = useTimelineStore((s) => s.activeDrawingTool);
+  const activeDrawingColor = useTimelineStore((s) => s.activeDrawingColor);
+  const activeDrawingStrokeWidth = useTimelineStore((s) => s.activeDrawingStrokeWidth);
+  const activeDrawingTexture = useTimelineStore((s) => s.activeDrawingTexture);
+  const activeDrawingWriteOnSpeed = useTimelineStore((s) => s.activeDrawingWriteOnSpeed);
+  const {
+    setActiveDrawingTool,
+    setActiveDrawingColor,
+    setActiveDrawingStrokeWidth,
+    setActiveDrawingTexture,
+    setActiveDrawingWriteOnSpeed,
+  } = useTimelineStore();
+
+  const speedLabel = activeDrawingWriteOnSpeed <= 0.5 ? '0.5× slow'
+    : activeDrawingWriteOnSpeed >= 2 ? '2× fast'
+    : `${activeDrawingWriteOnSpeed}×`;
+
+  return (
+    <section>
+      <div className="flex items-center gap-1.5 mb-2">
+        <Pen size={12} style={{ color: 'var(--bg-clip-drawing)' }} />
+        <span className="text-xs font-semibold" style={{ color: 'var(--text-primary)' }}>
+          Drawing
+        </span>
+      </div>
+
+      {/* Tool selector */}
+      <div className="mb-2">
+        <label className="text-xs block mb-1" style={{ color: 'var(--text-secondary)' }}>Tool</label>
+        <div className="flex gap-1">
+          {TOOLS.map(({ type, icon: Icon, label }) => (
+            <button
+              key={type}
+              onClick={() => setActiveDrawingTool(type)}
+              className="flex-1 flex flex-col items-center gap-0.5 px-1 py-1.5 rounded text-xs transition-colors"
+              style={{
+                background: activeDrawingTool === type ? 'var(--bg-clip-drawing)' : 'var(--bg-surface)',
+                color: activeDrawingTool === type ? 'white' : 'var(--text-secondary)',
+              }}
+              title={label}
+            >
+              <Icon size={12} />
+              <span style={{ fontSize: '0.6rem' }}>{label}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Texture selector */}
+      <div className="mb-2">
+        <label className="text-xs block mb-1" style={{ color: 'var(--text-secondary)' }}>Texture</label>
+        <div className="flex gap-1">
+          {TEXTURES.map(({ type, label }) => (
+            <button
+              key={type}
+              onClick={() => setActiveDrawingTexture(type)}
+              className="flex-1 px-2 py-1 rounded text-xs transition-colors"
+              style={{
+                background: activeDrawingTexture === type ? 'var(--bg-clip-drawing)' : 'var(--bg-surface)',
+                color: activeDrawingTexture === type ? 'white' : 'var(--text-secondary)',
+              }}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Color picker */}
+      <div className="mb-2">
+        <label className="text-xs block mb-1" style={{ color: 'var(--text-secondary)' }}>Color</label>
+        <div className="flex items-center gap-2">
+          <input
+            type="color"
+            value={activeDrawingColor}
+            onChange={(e) => setActiveDrawingColor(e.target.value)}
+            className="w-8 h-8 rounded cursor-pointer border-0"
+          />
+          <span className="text-xs font-mono" style={{ color: 'var(--text-secondary)' }}>
+            {activeDrawingColor}
+          </span>
+        </div>
+      </div>
+
+      {/* Stroke width */}
+      <div className="mb-2">
+        <label className="text-xs block mb-1" style={{ color: 'var(--text-secondary)' }}>
+          Size: {activeDrawingStrokeWidth}px
+        </label>
+        <input
+          type="range"
+          min={1}
+          max={20}
+          value={activeDrawingStrokeWidth}
+          onChange={(e) => setActiveDrawingStrokeWidth(Number(e.target.value))}
+          className="w-full"
+          style={{ accentColor: 'var(--bg-clip-drawing)' }}
+        />
+      </div>
+
+      {/* Write-on speed */}
+      <div className="mb-2">
+        <label className="text-xs block mb-1" style={{ color: 'var(--text-secondary)' }}>
+          Write-on speed: {speedLabel}
+        </label>
+        <input
+          type="range"
+          min={0.5}
+          max={2}
+          step={0.25}
+          value={activeDrawingWriteOnSpeed}
+          onChange={(e) => setActiveDrawingWriteOnSpeed(Number(e.target.value))}
+          className="w-full"
+          style={{ accentColor: 'var(--bg-clip-drawing)' }}
+        />
+        <div className="flex justify-between text-xs mt-0.5" style={{ color: 'var(--text-secondary)', fontSize: '0.6rem' }}>
+          <span>Slow</span>
+          <span>Fast</span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/settings/SettingsPanel.tsx
+++ b/src/components/settings/SettingsPanel.tsx
@@ -1,6 +1,7 @@
 import { Key, Monitor, Type, Palette } from 'lucide-react';
 import { useTimelineStore } from '../../store/timeline';
 import { useLanguage } from '../../context/LanguageProvider';
+import { DrawingToolPanel } from './DrawingToolPanel';
 import type { AspectRatio, CaptionStyle, TextStyle } from '../../types';
 
 const FONT_FAMILIES = [
@@ -10,6 +11,7 @@ const FONT_FAMILIES = [
 
 export function SettingsPanel() {
   const { settings, setAspectRatio, setDeepgramApiKey, setOpenaiApiKey, setCaptionStyle, setBackgroundColor } = useTimelineStore();
+  const activeTool = useTimelineStore((s) => s.activeTool);
   const selectedTextOverlayId = useTimelineStore((s) => s.selectedTextOverlayId);
   const textOverlays = useTimelineStore((s) => s.textOverlays);
   const updateTextOverlay = useTimelineStore((s) => s.updateTextOverlay);
@@ -68,6 +70,9 @@ export function SettingsPanel() {
       </div>
 
       <div className="flex-1 overflow-y-auto p-3 space-y-5">
+        {/* Drawing Tool Panel (when draw mode is active) */}
+        {activeTool === 'draw' && <DrawingToolPanel />}
+
         {/* Aspect Ratio */}
         <section>
           <div className="flex items-center gap-1.5 mb-2">

--- a/src/components/timeline/DrawingOverlayClip.tsx
+++ b/src/components/timeline/DrawingOverlayClip.tsx
@@ -1,0 +1,183 @@
+import { useRef, useCallback, useState, useEffect } from 'react';
+import { Pencil } from 'lucide-react';
+import { useTimelineStore, useTimelineStoreApi } from '../../store/timeline';
+import type { DrawingOverlay } from '../../types';
+
+interface Props {
+  overlay: DrawingOverlay;
+}
+
+export function DrawingOverlayClip({ overlay }: Props) {
+  const zoom = useTimelineStore((s) => s.zoom);
+  const selectedDrawingOverlayId = useTimelineStore((s) => s.selectedDrawingOverlayId);
+  const { selectDrawingOverlay, updateDrawingOverlay, removeDrawingOverlay, setActiveTool } = useTimelineStore();
+  const storeApi = useTimelineStoreApi();
+
+  const clipRef = useRef<HTMLDivElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [contextMenuPos, setContextMenuPos] = useState<{ x: number; y: number } | null>(null);
+  const dragStartRef = useRef({ x: 0, startTime: 0, duration: 0 });
+
+  const isSelected = selectedDrawingOverlayId === overlay.id;
+  const left = overlay.startTime * zoom;
+  const width = overlay.duration * zoom;
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent, type: 'move' | 'trim-end') => {
+      e.stopPropagation();
+      selectDrawingOverlay(overlay.id);
+      setIsDragging(true);
+      storeApi.temporal.getState().pause();
+      dragStartRef.current = { x: e.clientX, startTime: overlay.startTime, duration: overlay.duration };
+
+      const handleMouseMove = (moveEvent: MouseEvent) => {
+        const delta = (moveEvent.clientX - dragStartRef.current.x) / zoom;
+        const snapState = storeApi.getState();
+        const doSnap = snapState.snapEnabled;
+        const points = doSnap ? snapState.getSnapPoints() : [];
+        const threshold = 10 / zoom;
+
+        if (type === 'move') {
+          let newTime = Math.max(0, dragStartRef.current.startTime + delta);
+          if (doSnap) {
+            const dur = dragStartRef.current.duration;
+            let bestDist = threshold;
+            let snapped = newTime;
+            for (const sp of points) {
+              const dStart = Math.abs(newTime - sp);
+              if (dStart < bestDist) { snapped = sp; bestDist = dStart; }
+              const dEnd = Math.abs(newTime + dur - sp);
+              if (dEnd < bestDist) { snapped = sp - dur; bestDist = dEnd; }
+            }
+            newTime = Math.max(0, snapped);
+          }
+          // Detect cross-track drop (drawing tracks only)
+          let targetTrackId: string | undefined;
+          const els = document.elementsFromPoint(moveEvent.clientX, moveEvent.clientY);
+          for (const el of els) {
+            const tid = (el as HTMLElement).dataset?.trackId;
+            const ttype = (el as HTMLElement).dataset?.trackType;
+            if (tid && ttype === 'drawing') {
+              targetTrackId = tid !== overlay.trackId ? tid : undefined;
+              break;
+            }
+          }
+          updateDrawingOverlay(overlay.id, { startTime: newTime, ...(targetTrackId ? { trackId: targetTrackId } : {}) });
+        } else {
+          let newDuration = dragStartRef.current.duration + delta;
+          if (doSnap) {
+            const endTime = dragStartRef.current.startTime + newDuration;
+            let bestDist = threshold;
+            let snappedEnd = endTime;
+            for (const sp of points) {
+              if (Math.abs(endTime - sp) < bestDist) { snappedEnd = sp; bestDist = Math.abs(endTime - sp); }
+            }
+            newDuration = snappedEnd - dragStartRef.current.startTime;
+          }
+          if (newDuration > 0.5) {
+            updateDrawingOverlay(overlay.id, { duration: newDuration });
+          }
+        }
+      };
+
+      const handleMouseUp = () => {
+        setIsDragging(false);
+        storeApi.temporal.getState().resume();
+        window.removeEventListener('mousemove', handleMouseMove);
+        window.removeEventListener('mouseup', handleMouseUp);
+      };
+
+      window.addEventListener('mousemove', handleMouseMove);
+      window.addEventListener('mouseup', handleMouseUp);
+    },
+    [overlay, zoom, selectDrawingOverlay, updateDrawingOverlay, storeApi],
+  );
+
+  const handleDoubleClick = useCallback(() => {
+    selectDrawingOverlay(overlay.id);
+    setActiveTool('draw');
+  }, [overlay.id, selectDrawingOverlay, setActiveTool]);
+
+  const handleContextMenu = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    selectDrawingOverlay(overlay.id);
+    setContextMenuPos({ x: e.clientX, y: e.clientY });
+  }, [overlay.id, selectDrawingOverlay]);
+
+  useEffect(() => {
+    if (!contextMenuPos) return;
+    const handle = () => setContextMenuPos(null);
+    window.addEventListener('mousedown', handle);
+    return () => window.removeEventListener('mousedown', handle);
+  }, [contextMenuPos]);
+
+  return (
+    <div
+      ref={clipRef}
+      className="absolute top-0.5 bottom-0.5 flex items-center select-none group"
+      style={{
+        left,
+        width: Math.max(width, 4),
+        background: 'var(--bg-clip-drawing)',
+        opacity: isDragging ? 0.8 : 0.9,
+        borderRadius: 3,
+        border: isSelected ? '2px solid white' : '1px solid rgba(255,255,255,0.3)',
+        cursor: isDragging ? 'grabbing' : 'grab',
+        zIndex: isSelected ? 10 : 1,
+        overflow: 'hidden',
+      }}
+      onMouseDown={(e) => handleMouseDown(e, 'move')}
+      onDoubleClick={handleDoubleClick}
+      onContextMenu={handleContextMenu}
+      title="Double-click to draw • Drag to move • Right-click for options"
+    >
+      <div className="flex-1 h-full flex items-center px-2 gap-1 overflow-hidden">
+        <Pencil size={10} className="opacity-80 flex-shrink-0" style={{ color: 'white' }} />
+        <span className="text-xs truncate font-semibold" style={{ color: 'white', fontSize: '0.65rem' }}>
+          {overlay.strokes.length} stroke{overlay.strokes.length !== 1 ? 's' : ''}
+        </span>
+      </div>
+
+      {/* Trim handle right */}
+      <div
+        className="absolute right-0 top-0 bottom-0 w-1.5 cursor-col-resize z-20 hover:opacity-100 opacity-0 group-hover:opacity-100 transition-opacity"
+        style={{ background: 'rgba(0,0,0,0.4)' }}
+        onMouseDown={(e) => {
+          e.stopPropagation();
+          handleMouseDown(e, 'trim-end');
+        }}
+      />
+
+      {/* Context menu */}
+      {contextMenuPos && (
+        <div
+          className="fixed z-50 rounded shadow-lg py-1"
+          style={{
+            left: contextMenuPos.x,
+            top: contextMenuPos.y,
+            background: 'var(--bg-surface)',
+            border: '1px solid var(--border)',
+            minWidth: 120,
+          }}
+          onMouseDown={(e) => e.stopPropagation()}
+        >
+          <button
+            className="w-full text-left px-3 py-1 text-xs hover:opacity-80"
+            style={{ color: 'var(--text-primary)' }}
+            onClick={() => { setContextMenuPos(null); handleDoubleClick(); }}
+          >
+            Draw on layer
+          </button>
+          <button
+            className="w-full text-left px-3 py-1 text-xs hover:opacity-80"
+            style={{ color: '#ef4444' }}
+            onClick={() => { setContextMenuPos(null); removeDrawingOverlay(overlay.id); }}
+          >
+            Delete
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -31,6 +31,7 @@ export function Timeline() {
   const videoTracks = tracks.filter((t) => t.type === 'video');
   const audioTracks = tracks.filter((t) => t.type === 'audio');
   const textTracks = tracks.filter((t) => t.type === 'text');
+  const drawingTracks = tracks.filter((t) => t.type === 'drawing');
   const totalWidth = duration * zoom;
 
   // Marquee selection state
@@ -59,6 +60,13 @@ export function Timeline() {
     if (textTracks.length > 0) y += 2; // A/T divider
 
     textTracks.forEach((track) => {
+      positions[track.id] = { top: y, height: track.height };
+      y += track.height;
+    });
+
+    if (drawingTracks.length > 0) y += 2; // T/D divider
+
+    drawingTracks.forEach((track) => {
       positions[track.id] = { top: y, height: track.height };
       y += track.height;
     });
@@ -202,6 +210,13 @@ export function Timeline() {
           >
             <Plus size={10} /> {t.timeline.text}
           </button>
+          <button
+            onClick={() => addTrack('drawing')}
+            className="flex items-center gap-1 px-2 py-0.5 rounded text-xs transition-colors hover:opacity-80"
+            style={{ color: 'var(--bg-clip-drawing)', border: '1px solid var(--bg-clip-drawing)' }}
+          >
+            <Plus size={10} /> Drawing
+          </button>
         </div>
       </div>
 
@@ -243,6 +258,19 @@ export function Timeline() {
 
           {/* Text tracks */}
           {textTracks.map((track) => (
+            <TimelineTrack key={track.id} track={track} />
+          ))}
+
+          {/* T/D divider */}
+          {drawingTracks.length > 0 && (
+            <div className="flex" style={{ height: 2, background: 'var(--border)' }}>
+              <div style={{ width: 100 }} />
+              <div className="flex-1" />
+            </div>
+          )}
+
+          {/* Drawing tracks */}
+          {drawingTracks.map((track) => (
             <TimelineTrack key={track.id} track={track} />
           ))}
 

--- a/src/components/timeline/TimelineTrack.tsx
+++ b/src/components/timeline/TimelineTrack.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useState, useRef } from 'react';
-import { Volume2, VolumeX, Lock, Unlock, Eye, EyeOff, Type } from 'lucide-react';
+import { Volume2, VolumeX, Lock, Unlock, Eye, EyeOff, Type, Pencil } from 'lucide-react';
 import { useTimelineStore } from '../../store/timeline';
 import { useLanguage } from '../../context/LanguageProvider';
 import { TimelineClipComponent } from './TimelineClip';
 import { TextOverlayClip } from './TextOverlayClip';
+import { DrawingOverlayClip } from './DrawingOverlayClip';
 import type { Track } from '../../types';
 
 interface Props {
@@ -13,6 +14,7 @@ interface Props {
 export function TimelineTrack({ track }: Props) {
   const clips = useTimelineStore((s) => s.clips);
   const textOverlays = useTimelineStore((s) => s.textOverlays);
+  const drawingOverlays = useTimelineStore((s) => s.drawingOverlays);
   const zoom = useTimelineStore((s) => s.zoom);
   const duration = useTimelineStore((s) => s.duration);
   const activeTool = useTimelineStore((s) => s.activeTool);
@@ -32,26 +34,35 @@ export function TimelineTrack({ track }: Props) {
     .filter((o) => o.trackId === track.id)
     .sort((a, b) => a.startTime - b.startTime);
 
+  const trackDrawingOverlays = Object.values(drawingOverlays)
+    .filter((o) => o.trackId === track.id)
+    .sort((a, b) => a.startTime - b.startTime);
+
   const totalWidth = duration * zoom;
   const isVideo = track.type === 'video';
   const isText = track.type === 'text';
+  const isDrawing = track.type === 'drawing';
 
   const trackColor = isVideo
     ? 'var(--bg-clip-video)'
     : isText
       ? 'var(--filler-highlight)'
-      : 'var(--bg-clip-audio)';
+      : isDrawing
+        ? 'var(--bg-clip-drawing)'
+        : 'var(--bg-clip-audio)';
 
   const bgTint = isVideo
     ? 'rgba(59, 130, 246, 0.05)'
     : isText
       ? 'rgba(245, 158, 11, 0.05)'
-      : 'rgba(34, 197, 94, 0.05)';
+      : isDrawing
+        ? 'rgba(14, 165, 233, 0.05)'
+        : 'rgba(34, 197, 94, 0.05)';
 
   const handleDrop = useCallback(
     (e: React.DragEvent) => {
       e.preventDefault();
-      if (isText) return; // Text tracks don't accept media drops
+      if (isText || isDrawing) return; // Overlay tracks don't accept media drops
       const mediaFileId = e.dataTransfer.getData('application/x-cutlass-media');
       if (!mediaFileId) return;
 
@@ -100,7 +111,9 @@ export function TimelineTrack({ track }: Props) {
     ? (track.muted ? EyeOff : Eye)
     : isText
       ? (track.muted ? EyeOff : Type)
-      : (track.muted ? VolumeX : Volume2);
+      : isDrawing
+        ? (track.muted ? EyeOff : Pencil)
+        : (track.muted ? VolumeX : Volume2);
 
   return (
     <div className="flex" style={{ height: track.height }}>
@@ -136,7 +149,7 @@ export function TimelineTrack({ track }: Props) {
         </button>
 
         {/* Track volume - click label to toggle slider */}
-        {!isText && (
+        {!isText && !isDrawing && (
           <button
             className="text-xs ml-auto"
             style={{ color: 'var(--text-secondary)', fontSize: 9 }}
@@ -148,7 +161,7 @@ export function TimelineTrack({ track }: Props) {
         )}
 
         {/* Inline volume slider */}
-        {showVolumeSlider && !isText && (
+        {showVolumeSlider && !isText && !isDrawing && (
           <input
             type="range"
             min={0}
@@ -183,6 +196,11 @@ export function TimelineTrack({ track }: Props) {
         {/* Text overlays */}
         {trackTextOverlays.map((overlay) => (
           <TextOverlayClip key={overlay.id} overlay={overlay} />
+        ))}
+
+        {/* Drawing overlays */}
+        {trackDrawingOverlays.map((overlay) => (
+          <DrawingOverlayClip key={overlay.id} overlay={overlay} />
         ))}
 
         {/* Inline text input for new overlay (replaces browser prompt) */}

--- a/src/components/toolbar/Toolbar.tsx
+++ b/src/components/toolbar/Toolbar.tsx
@@ -6,6 +6,7 @@ import {
   MousePointer2,
   Scissors,
   Type,
+  Pen,
   Undo2,
   Redo2,
   ZoomIn,
@@ -54,6 +55,7 @@ export function Toolbar() {
     { tool: 'select', icon: MousePointer2, label: t.toolbar.select, shortcut: 'V' },
     { tool: 'razor', icon: Scissors, label: t.toolbar.razor, shortcut: 'C' },
     { tool: 'text', icon: Type, label: t.toolbar.text, shortcut: 'T' },
+    { tool: 'draw', icon: Pen, label: 'Draw', shortcut: 'D' },
   ];
 
   return (

--- a/src/components/viewer/DrawingCanvas.tsx
+++ b/src/components/viewer/DrawingCanvas.tsx
@@ -1,0 +1,178 @@
+import { useRef, useState, useCallback } from 'react';
+import { v4 as uuid } from 'uuid';
+import { useTimelineStore } from '../../store/timeline';
+import { DrawingStrokeRenderer } from './DrawingStrokeRenderer';
+import type { DrawingPoint, DrawingStroke } from '../../types';
+
+interface Props {
+  width: number;
+  height: number;
+  activeOverlayId: string | null;
+  /** Called when the user starts drawing and no overlay is selected */
+  onNeedOverlay: () => string;
+}
+
+export function DrawingCanvas({ width, height, activeOverlayId, onNeedOverlay }: Props) {
+  const svgRef = useRef<SVGSVGElement>(null);
+
+  const drawingOverlays = useTimelineStore((s) => s.drawingOverlays);
+  const activeDrawingTool = useTimelineStore((s) => s.activeDrawingTool);
+  const activeDrawingColor = useTimelineStore((s) => s.activeDrawingColor);
+  const activeDrawingStrokeWidth = useTimelineStore((s) => s.activeDrawingStrokeWidth);
+  const activeDrawingTexture = useTimelineStore((s) => s.activeDrawingTexture);
+  const activeDrawingWriteOnSpeed = useTimelineStore((s) => s.activeDrawingWriteOnSpeed);
+  const { addStrokeToDrawingOverlay } = useTimelineStore();
+
+  // In-progress stroke points (not yet committed to store)
+  const [inProgressPoints, setInProgressPoints] = useState<DrawingPoint[]>([]);
+  const activeOverlayIdRef = useRef(activeOverlayId);
+  activeOverlayIdRef.current = activeOverlayId;
+
+  const getOpacityForTexture = useCallback(() => {
+    if (activeDrawingTexture === 'marker') return 0.5;
+    if (activeDrawingTexture === 'chalk') return 0.7;
+    return 1;
+  }, [activeDrawingTexture]);
+
+  const toNormalized = useCallback((clientX: number, clientY: number): DrawingPoint => {
+    const svg = svgRef.current;
+    if (!svg) return { x: 0, y: 0 };
+    const rect = svg.getBoundingClientRect();
+    return {
+      x: Math.max(0, Math.min(1, (clientX - rect.left) / rect.width)),
+      y: Math.max(0, Math.min(1, (clientY - rect.top) / rect.height)),
+    };
+  }, []);
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<SVGSVGElement>) => {
+      e.preventDefault();
+      (e.target as Element).setPointerCapture(e.pointerId);
+
+      const pt = toNormalized(e.clientX, e.clientY);
+      setInProgressPoints([pt]);
+    },
+    [toNormalized],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent<SVGSVGElement>) => {
+      if (e.buttons === 0) return; // no button held
+      const pt = toNormalized(e.clientX, e.clientY);
+      setInProgressPoints((prev) => {
+        if (prev.length === 0) return prev;
+        // For shapes (arrow/circle/rectangle), only keep first + current
+        if (activeDrawingTool !== 'pen') {
+          return [prev[0], pt];
+        }
+        return [...prev, pt];
+      });
+    },
+    [toNormalized, activeDrawingTool],
+  );
+
+  const handlePointerUp = useCallback(
+    (e: React.PointerEvent<SVGSVGElement>) => {
+      if (inProgressPoints.length < 1) return;
+
+      // Ensure we have an overlay to attach to
+      let overlayId = activeOverlayIdRef.current;
+      if (!overlayId) {
+        overlayId = onNeedOverlay();
+      }
+
+      const needsMinPoints = activeDrawingTool !== 'pen';
+      const points = inProgressPoints;
+      const hasEnoughPoints = needsMinPoints ? points.length >= 2 : points.length >= 2;
+
+      if (hasEnoughPoints && overlayId) {
+        const stroke: DrawingStroke = {
+          id: uuid(),
+          tool: activeDrawingTool,
+          texture: activeDrawingTexture,
+          color: activeDrawingColor,
+          strokeWidth: activeDrawingStrokeWidth,
+          opacity: getOpacityForTexture(),
+          points,
+        };
+        addStrokeToDrawingOverlay(overlayId, stroke);
+      }
+
+      setInProgressPoints([]);
+    },
+    [
+      inProgressPoints,
+      activeDrawingTool,
+      activeDrawingTexture,
+      activeDrawingColor,
+      activeDrawingStrokeWidth,
+      getOpacityForTexture,
+      addStrokeToDrawingOverlay,
+      onNeedOverlay,
+    ],
+  );
+
+  const activeOverlay = activeOverlayId ? drawingOverlays[activeOverlayId] : null;
+
+  // Build in-progress stroke for preview
+  const inProgressStroke: DrawingStroke | null =
+    inProgressPoints.length >= 1
+      ? {
+          id: 'in-progress',
+          tool: activeDrawingTool,
+          texture: activeDrawingTexture,
+          color: activeDrawingColor,
+          strokeWidth: activeDrawingStrokeWidth,
+          opacity: getOpacityForTexture(),
+          points: inProgressPoints,
+        }
+      : null;
+
+  return (
+    <svg
+      ref={svgRef}
+      style={{
+        position: 'absolute',
+        inset: 0,
+        width: '100%',
+        height: '100%',
+        zIndex: 20,
+        cursor: activeDrawingTool === 'pen' ? 'crosshair'
+          : activeDrawingTool === 'arrow' ? 'crosshair'
+          : 'crosshair',
+        touchAction: 'none',
+      }}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+    >
+      <defs>
+        <filter id="cutlass-chalk-filter" x="-5%" y="-5%" width="110%" height="110%">
+          <feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="4" result="noise" />
+          <feDisplacementMap in="SourceGraphic" in2="noise" scale="2" xChannelSelector="R" yChannelSelector="G" />
+        </filter>
+      </defs>
+
+      {/* Committed strokes for the active overlay */}
+      {activeOverlay?.strokes.map((stroke) => (
+        <DrawingStrokeRenderer
+          key={stroke.id}
+          stroke={stroke}
+          canvasWidth={width}
+          canvasHeight={height}
+          revealFraction={1}
+        />
+      ))}
+
+      {/* In-progress stroke preview */}
+      {inProgressStroke && (
+        <DrawingStrokeRenderer
+          stroke={inProgressStroke}
+          canvasWidth={width}
+          canvasHeight={height}
+          revealFraction={1}
+        />
+      )}
+    </svg>
+  );
+}

--- a/src/components/viewer/DrawingCanvas.tsx
+++ b/src/components/viewer/DrawingCanvas.tsx
@@ -20,7 +20,6 @@ export function DrawingCanvas({ width, height, activeOverlayId, onNeedOverlay }:
   const activeDrawingColor = useTimelineStore((s) => s.activeDrawingColor);
   const activeDrawingStrokeWidth = useTimelineStore((s) => s.activeDrawingStrokeWidth);
   const activeDrawingTexture = useTimelineStore((s) => s.activeDrawingTexture);
-  const activeDrawingWriteOnSpeed = useTimelineStore((s) => s.activeDrawingWriteOnSpeed);
   const { addStrokeToDrawingOverlay } = useTimelineStore();
 
   // In-progress stroke points (not yet committed to store)
@@ -72,7 +71,7 @@ export function DrawingCanvas({ width, height, activeOverlayId, onNeedOverlay }:
   );
 
   const handlePointerUp = useCallback(
-    (e: React.PointerEvent<SVGSVGElement>) => {
+    (_e: React.PointerEvent<SVGSVGElement>) => {
       if (inProgressPoints.length < 1) return;
 
       // Ensure we have an overlay to attach to

--- a/src/components/viewer/DrawingStrokeRenderer.tsx
+++ b/src/components/viewer/DrawingStrokeRenderer.tsx
@@ -1,0 +1,139 @@
+import type { DrawingStroke } from '../../types';
+
+interface Props {
+  stroke: DrawingStroke;
+  canvasWidth: number;
+  canvasHeight: number;
+  /** Fraction 0–1 of the stroke to reveal (write-on animation). 1 = fully visible. */
+  revealFraction?: number;
+}
+
+/** Convert normalized 0-1 point to pixel SVG coordinate string */
+function px(points: { x: number; y: number }[], w: number, h: number): string {
+  if (points.length === 0) return '';
+  const first = `M ${points[0].x * w} ${points[0].y * h}`;
+  const rest = points.slice(1).map((p) => `L ${p.x * w} ${p.y * h}`).join(' ');
+  return rest ? `${first} ${rest}` : first;
+}
+
+/** Euclidean path length in pixels (sum of segment lengths) */
+function pathLength(points: { x: number; y: number }[], w: number, h: number): number {
+  let len = 0;
+  for (let i = 1; i < points.length; i++) {
+    const dx = (points[i].x - points[i - 1].x) * w;
+    const dy = (points[i].y - points[i - 1].y) * h;
+    len += Math.sqrt(dx * dx + dy * dy);
+  }
+  return len;
+}
+
+/** Compute arrowhead polygon points for arrow strokes */
+function arrowheadPoints(
+  p0: { x: number; y: number },
+  p1: { x: number; y: number },
+  w: number,
+  h: number,
+  size: number,
+): string {
+  const ax = p0.x * w, ay = p0.y * h;
+  const bx = p1.x * w, by = p1.y * h;
+  const angle = Math.atan2(by - ay, bx - ax);
+  const left = { x: bx - size * Math.cos(angle - Math.PI / 6), y: by - size * Math.sin(angle - Math.PI / 6) };
+  const right = { x: bx - size * Math.cos(angle + Math.PI / 6), y: by - size * Math.sin(angle + Math.PI / 6) };
+  return `${bx},${by} ${left.x},${left.y} ${right.x},${right.y}`;
+}
+
+export function DrawingStrokeRenderer({ stroke, canvasWidth: w, canvasHeight: h, revealFraction = 1 }: Props) {
+  const rf = Math.max(0, Math.min(1, revealFraction));
+
+  const commonProps = {
+    stroke: stroke.color,
+    strokeWidth: stroke.strokeWidth * (w / 1920),
+    fill: 'none',
+    strokeLinecap: 'round' as const,
+    strokeLinejoin: 'round' as const,
+    opacity: stroke.opacity,
+    filter: stroke.texture === 'chalk' ? 'url(#cutlass-chalk-filter)' : undefined,
+  };
+
+  if (stroke.tool === 'pen') {
+    if (stroke.points.length < 2) return null;
+    const d = px(stroke.points, w, h);
+    const totalLen = pathLength(stroke.points, w, h);
+    return (
+      <path
+        d={d}
+        {...commonProps}
+        strokeDasharray={totalLen}
+        strokeDashoffset={totalLen * (1 - rf)}
+      />
+    );
+  }
+
+  if (stroke.tool === 'arrow') {
+    if (stroke.points.length < 2) return null;
+    const [p0, p1] = stroke.points;
+    const lineLen = Math.sqrt(
+      ((p1.x - p0.x) * w) ** 2 + ((p1.y - p0.y) * h) ** 2,
+    );
+    const arrowSize = Math.max(10, stroke.strokeWidth * (w / 1920) * 4);
+    const headPoints = arrowheadPoints(p0, p1, w, h, arrowSize);
+    const dashTotal = lineLen + arrowSize * 2;
+    return (
+      <g opacity={stroke.opacity} filter={stroke.texture === 'chalk' ? 'url(#cutlass-chalk-filter)' : undefined}>
+        <line
+          x1={p0.x * w} y1={p0.y * h}
+          x2={p1.x * w} y2={p1.y * h}
+          stroke={stroke.color}
+          strokeWidth={stroke.strokeWidth * (w / 1920)}
+          strokeLinecap="round"
+          strokeDasharray={dashTotal}
+          strokeDashoffset={dashTotal * (1 - rf)}
+        />
+        {rf > 0.9 && (
+          <polygon
+            points={headPoints}
+            fill={stroke.color}
+            opacity={Math.max(0, (rf - 0.9) * 10)}
+          />
+        )}
+      </g>
+    );
+  }
+
+  if (stroke.tool === 'circle') {
+    if (stroke.points.length < 2) return null;
+    const [center, edge] = stroke.points;
+    const rx = Math.abs((edge.x - center.x) * w);
+    const ry = Math.abs((edge.y - center.y) * h);
+    const circumference = 2 * Math.PI * Math.max(rx, ry);
+    return (
+      <ellipse
+        cx={center.x * w} cy={center.y * h}
+        rx={rx} ry={ry}
+        {...commonProps}
+        strokeDasharray={circumference}
+        strokeDashoffset={circumference * (1 - rf)}
+      />
+    );
+  }
+
+  if (stroke.tool === 'rectangle') {
+    if (stroke.points.length < 2) return null;
+    const [tl, br] = stroke.points;
+    const rx = tl.x * w, ry = tl.y * h;
+    const rw = (br.x - tl.x) * w, rh = (br.y - tl.y) * h;
+    const perimeter = 2 * (Math.abs(rw) + Math.abs(rh));
+    return (
+      <rect
+        x={Math.min(rx, rx + rw)} y={Math.min(ry, ry + rh)}
+        width={Math.abs(rw)} height={Math.abs(rh)}
+        {...commonProps}
+        strokeDasharray={perimeter}
+        strokeDashoffset={perimeter * (1 - rf)}
+      />
+    );
+  }
+
+  return null;
+}

--- a/src/components/viewer/Viewer.tsx
+++ b/src/components/viewer/Viewer.tsx
@@ -114,20 +114,28 @@ export function Viewer() {
   const displayWidth = Math.min(videoAreaSize.width, videoAreaSize.height * ar);
   const displayHeight = displayWidth / ar;
 
-  // Find the active video clip at the current playhead position (video type only)
+  // Find the active video clip at the current playhead position (video type only).
+  // When clips on multiple video tracks overlap, pick the one from the highest-index
+  // track — that is the top rendered layer, consistent with the export sort order.
   const activeClip = useMemo(() => {
     const videoTrackIds = new Set(
       tracks.filter((t) => t.type === 'video').map((t) => t.id),
     );
-    return (
-      Object.values(clips).find(
-        (c) =>
-          c.type === 'video' &&
-          videoTrackIds.has(c.trackId) &&
-          playheadPosition >= c.startTime &&
-          playheadPosition < c.startTime + c.duration,
-      ) ?? null
+    const candidates = Object.values(clips).filter(
+      (c) =>
+        c.type === 'video' &&
+        videoTrackIds.has(c.trackId) &&
+        playheadPosition >= c.startTime &&
+        playheadPosition < c.startTime + c.duration,
     );
+    if (candidates.length === 0) return null;
+    if (candidates.length === 1) return candidates[0];
+    // Return the clip whose track has the highest index (rendered last = on top in export)
+    return candidates.reduce((best, clip) => {
+      const clipIdx = tracks.findIndex((t) => t.id === clip.trackId);
+      const bestIdx = tracks.findIndex((t) => t.id === best.trackId);
+      return clipIdx > bestIdx ? clip : best;
+    });
   }, [tracks, clips, playheadPosition]);
 
   // Image clips active at the current playhead (rendered as overlays on top of video)

--- a/src/components/viewer/Viewer.tsx
+++ b/src/components/viewer/Viewer.tsx
@@ -2,7 +2,9 @@ import { useRef, useEffect, useCallback, useMemo, useState } from 'react';
 import { Maximize2 } from 'lucide-react';
 import { useTimelineStore } from '../../store/timeline';
 import { useLanguage } from '../../context/LanguageProvider';
-import type { AnimationPreset } from '../../types';
+import { DrawingCanvas } from './DrawingCanvas';
+import { DrawingStrokeRenderer } from './DrawingStrokeRenderer';
+import type { AnimationPreset, DrawingOverlay } from '../../types';
 
 /** Compute fade volume multiplier (0–1) for a clip at the given playhead position */
 function computeVideoFadeMultiplier(clip: { startTime: number; duration: number; fadeIn: number; fadeOut: number }, playheadPosition: number): number {
@@ -92,6 +94,10 @@ export function Viewer() {
   const tracks = useTimelineStore((s) => s.tracks);
   const mediaFiles = useTimelineStore((s) => s.mediaFiles);
   const textOverlays = useTimelineStore((s) => s.textOverlays);
+  const drawingOverlays = useTimelineStore((s) => s.drawingOverlays);
+  const activeTool = useTimelineStore((s) => s.activeTool);
+  const selectedDrawingOverlayId = useTimelineStore((s) => s.selectedDrawingOverlayId);
+  const { addDrawingOverlay, addTrack, selectDrawingOverlay } = useTimelineStore();
   const resolution = useTimelineStore((s) => s.settings.resolution);
   const backgroundColor = useTimelineStore((s) => s.settings.backgroundColor ?? '#000000');
   const { t } = useLanguage();
@@ -187,7 +193,47 @@ export function Viewer() {
     );
   }, [textOverlays, playheadPosition]);
 
+  // Drawing overlays active at current playhead
+  const activeDrawingOverlays = useMemo(() => {
+    return Object.values(drawingOverlays).filter(
+      (o) => playheadPosition >= o.startTime && playheadPosition < o.startTime + o.duration,
+    );
+  }, [drawingOverlays, playheadPosition]);
+
   const fontScale = displayWidth / resolution.width;
+
+  /** Compute write-on reveal fraction (0–1) for a drawing overlay at elapsed seconds */
+  function computeRevealFraction(overlay: DrawingOverlay, elapsed: number): number {
+    if (elapsed <= 0) return 0;
+    const totalDuration = Math.max(0.5, overlay.strokes.length * 0.3 / (overlay.writeOnSpeed ?? 1));
+    return Math.min(1, elapsed / totalDuration);
+  }
+
+  /** Compute fade opacity for drawing/text overlays */
+  function computeOverlayOpacity(overlay: { startTime: number; duration: number; fadeIn?: number; fadeOut?: number }): number {
+    const elapsed = playheadPosition - overlay.startTime;
+    const remaining = overlay.startTime + overlay.duration - playheadPosition;
+    let opacity = 1;
+    if (overlay.fadeIn && overlay.fadeIn > 0 && elapsed < overlay.fadeIn) {
+      opacity = Math.max(0, elapsed / overlay.fadeIn);
+    }
+    if (overlay.fadeOut && overlay.fadeOut > 0 && remaining < overlay.fadeOut) {
+      opacity = Math.min(opacity, Math.max(0, remaining / overlay.fadeOut));
+    }
+    return opacity;
+  }
+
+  /** Called by DrawingCanvas when no overlay is active — creates one automatically */
+  const handleNeedOverlay = useCallback((): string => {
+    // Find or create a drawing track
+    let drawingTrackId = tracks.find((t) => t.type === 'drawing')?.id;
+    if (!drawingTrackId) {
+      drawingTrackId = addTrack('drawing');
+    }
+    const newId = addDrawingOverlay(drawingTrackId, playheadPosition);
+    selectDrawingOverlay(newId);
+    return newId;
+  }, [tracks, addTrack, addDrawingOverlay, selectDrawingOverlay, playheadPosition]);
 
   // Sync video element with playhead
   useEffect(() => {
@@ -325,16 +371,7 @@ export function Viewer() {
 
           {/* Text overlays */}
           {activeTextOverlays.map((overlay) => {
-            // Compute fade opacity for this overlay
-            const elapsed = playheadPosition - overlay.startTime;
-            const remaining = overlay.startTime + overlay.duration - playheadPosition;
-            let textOpacity = 1;
-            if (overlay.fadeIn && overlay.fadeIn > 0 && elapsed < overlay.fadeIn) {
-              textOpacity = Math.max(0, elapsed / overlay.fadeIn);
-            }
-            if (overlay.fadeOut && overlay.fadeOut > 0 && remaining < overlay.fadeOut) {
-              textOpacity = Math.min(textOpacity, Math.max(0, remaining / overlay.fadeOut));
-            }
+            const textOpacity = computeOverlayOpacity(overlay);
             return (
               <div
                 key={overlay.id}
@@ -363,6 +400,55 @@ export function Viewer() {
               </div>
             );
           })}
+
+          {/* Drawing overlays SVG layer (playback read-only) */}
+          {activeDrawingOverlays.length > 0 && activeTool !== 'draw' && (
+            <svg
+              style={{
+                position: 'absolute',
+                inset: 0,
+                width: '100%',
+                height: '100%',
+                pointerEvents: 'none',
+                zIndex: 15,
+              }}
+            >
+              <defs>
+                <filter id="cutlass-chalk-filter" x="-5%" y="-5%" width="110%" height="110%">
+                  <feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="4" result="noise" />
+                  <feDisplacementMap in="SourceGraphic" in2="noise" scale="2" xChannelSelector="R" yChannelSelector="G" />
+                </filter>
+              </defs>
+              {activeDrawingOverlays.map((overlay) => {
+                const elapsed = playheadPosition - overlay.startTime;
+                const revealFraction = computeRevealFraction(overlay, elapsed);
+                const drawOpacity = computeOverlayOpacity(overlay);
+                return (
+                  <g key={overlay.id} opacity={drawOpacity}>
+                    {overlay.strokes.map((stroke) => (
+                      <DrawingStrokeRenderer
+                        key={stroke.id}
+                        stroke={stroke}
+                        canvasWidth={displayWidth}
+                        canvasHeight={displayHeight}
+                        revealFraction={revealFraction}
+                      />
+                    ))}
+                  </g>
+                );
+              })}
+            </svg>
+          )}
+
+          {/* Interactive drawing canvas (draw mode only) */}
+          {activeTool === 'draw' && (
+            <DrawingCanvas
+              width={displayWidth}
+              height={displayHeight}
+              activeOverlayId={selectedDrawingOverlayId}
+              onNeedOverlay={handleNeedOverlay}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -93,6 +93,8 @@ export function useKeyboardShortcuts() {
             for (const id of [...store.selectedClipIds]) {
               store.duplicateClip(id);
             }
+          } else if (!isMeta) {
+            store.setActiveTool('draw');
           }
           break;
 

--- a/src/index.css
+++ b/src/index.css
@@ -15,6 +15,7 @@
   --playhead: #ef4444;
   --filler-highlight: #f59e0b;
   --scene-border: #8b5cf6;
+  --bg-clip-drawing: #0ea5e9;
 }
 
 * {

--- a/src/services/export.ts
+++ b/src/services/export.ts
@@ -1,7 +1,7 @@
 import { FFmpeg } from '@ffmpeg/ffmpeg';
 import { fetchFile, toBlobURL } from '@ffmpeg/util';
 import type { TimelineState } from '../store/timeline';
-import type { ExportSettings, TimelineClip } from '../types';
+import type { ExportSettings, TimelineClip, DrawingOverlay } from '../types';
 import { track } from './analytics';
 
 /** Convert CSS color notation to FFmpeg color format.
@@ -73,6 +73,98 @@ async function getFFmpeg(onProgress: (progress: number) => void): Promise<FFmpeg
   return ffmpeg;
 }
 
+/** Render all strokes of a DrawingOverlay onto an OffscreenCanvas and return a PNG Uint8Array.
+ *  Used for static burn-in during export (v1 — write-on animation is preview-only). */
+async function renderDrawingOverlayToPng(
+  overlay: DrawingOverlay,
+  width: number,
+  height: number,
+): Promise<Uint8Array> {
+  const offscreen = new OffscreenCanvas(width, height);
+  const ctx = offscreen.getContext('2d')!;
+  ctx.clearRect(0, 0, width, height);
+
+  for (const stroke of overlay.strokes) {
+    const { tool, points, color, strokeWidth, opacity, texture } = stroke;
+    if (points.length < 1) continue;
+
+    ctx.save();
+    ctx.strokeStyle = color;
+    ctx.lineWidth = strokeWidth;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+
+    if (texture === 'marker') {
+      ctx.globalAlpha = 0.5;
+      ctx.lineCap = 'square';
+    } else {
+      ctx.globalAlpha = opacity;
+    }
+
+    if (tool === 'pen') {
+      if (points.length < 2) { ctx.restore(); continue; }
+      ctx.beginPath();
+      ctx.moveTo(points[0].x * width, points[0].y * height);
+      for (let i = 1; i < points.length; i++) {
+        ctx.lineTo(points[i].x * width, points[i].y * height);
+      }
+      if (texture === 'chalk') {
+        ctx.stroke();
+        ctx.globalAlpha *= 0.35;
+        ctx.lineWidth += 1;
+        ctx.stroke();
+        ctx.stroke();
+      } else {
+        ctx.stroke();
+      }
+    } else if (tool === 'arrow') {
+      if (points.length < 2) { ctx.restore(); continue; }
+      const p0 = points[0];
+      const p1 = points[points.length - 1];
+      const x0 = p0.x * width, y0 = p0.y * height;
+      const x1 = p1.x * width, y1 = p1.y * height;
+      ctx.beginPath();
+      ctx.moveTo(x0, y0);
+      ctx.lineTo(x1, y1);
+      ctx.stroke();
+      const angle = Math.atan2(y1 - y0, x1 - x0);
+      const size = Math.max(10, strokeWidth * 4);
+      ctx.beginPath();
+      ctx.moveTo(x1, y1);
+      ctx.lineTo(x1 - size * Math.cos(angle - Math.PI / 6), y1 - size * Math.sin(angle - Math.PI / 6));
+      ctx.lineTo(x1 - size * Math.cos(angle + Math.PI / 6), y1 - size * Math.sin(angle + Math.PI / 6));
+      ctx.closePath();
+      ctx.fillStyle = color;
+      ctx.fill();
+    } else if (tool === 'circle') {
+      if (points.length < 2) { ctx.restore(); continue; }
+      const cx = points[0].x * width;
+      const cy = points[0].y * height;
+      const ex = points[points.length - 1].x * width;
+      const ey = points[points.length - 1].y * height;
+      const rx = Math.abs(ex - cx);
+      const ry = Math.abs(ey - cy);
+      if (rx < 1 || ry < 1) { ctx.restore(); continue; }
+      ctx.beginPath();
+      ctx.ellipse(cx, cy, rx, ry, 0, 0, 2 * Math.PI);
+      ctx.stroke();
+    } else if (tool === 'rectangle') {
+      if (points.length < 2) { ctx.restore(); continue; }
+      const x1 = points[0].x * width;
+      const y1 = points[0].y * height;
+      const x2 = points[points.length - 1].x * width;
+      const y2 = points[points.length - 1].y * height;
+      ctx.strokeRect(Math.min(x1, x2), Math.min(y1, y2), Math.abs(x2 - x1), Math.abs(y2 - y1));
+    }
+
+    ctx.restore();
+  }
+
+  const blob = await offscreen.convertToBlob({ type: 'image/png' });
+  const ab = await blob.arrayBuffer();
+  return new Uint8Array(ab);
+}
+
 export async function exportTimeline(
   state: TimelineState,
   settings: ExportSettings,
@@ -83,6 +175,7 @@ export async function exportTimeline(
   onProgress(5);
 
   const { clips, mediaFiles, tracks, textOverlays, transcripts } = state;
+  const drawingOverlays = state.drawingOverlays ?? {};
   const { resolution, frameRate, backgroundColor } = state.settings;
 
   // Collect all media files used by clips
@@ -197,6 +290,9 @@ export async function exportTimeline(
   Object.values(textOverlays).forEach((o) => {
     timelineDuration = Math.max(timelineDuration, o.startTime + o.duration);
   });
+  Object.values(drawingOverlays).forEach((o) => {
+    timelineDuration = Math.max(timelineDuration, o.startTime + o.duration);
+  });
   if (timelineDuration === 0) {
     throw new Error('Nothing to export - timeline is empty');
   }
@@ -212,12 +308,30 @@ export async function exportTimeline(
   });
   const exportStartMs = Date.now();
 
+  // Render drawing overlay PNGs for export (static burn-in; write-on is preview-only in v1)
+  const drawingPngFiles: { filename: string; overlay: DrawingOverlay; inputIdx: number }[] = [];
+  const drawingOverlaysList = Object.values(drawingOverlays).filter((o) => o.strokes.length > 0);
+  for (let i = 0; i < drawingOverlaysList.length; i++) {
+    const overlay = drawingOverlaysList[i];
+    try {
+      const pngData = await renderDrawingOverlayToPng(overlay, resolution.width, resolution.height);
+      const filename = `drawing_${i}.png`;
+      await ff.writeFile(filename, pngData);
+      drawingPngFiles.push({ filename, overlay, inputIdx: inputFiles.length + i });
+    } catch { /* skip overlay if rendering fails */ }
+  }
+
   // Build ffmpeg command
   const args: string[] = [];
 
-  // Input files
+  // Input files (media)
   for (const filename of inputFiles) {
     args.push('-i', filename);
+  }
+
+  // Drawing PNG inputs (-loop 1 = static image looped for its overlay duration)
+  for (const dpf of drawingPngFiles) {
+    args.push('-loop', '1', '-i', dpf.filename);
   }
 
   // Create background canvas with user-selected color
@@ -226,7 +340,7 @@ export async function exportTimeline(
     '-f', 'lavfi',
     '-i', `color=c=${bgColor}:s=${resolution.width}x${resolution.height}:r=${frameRate}:d=${timelineDuration}`,
   );
-  const canvasIdx = inputFiles.length;
+  const canvasIdx = inputFiles.length + drawingPngFiles.length;
 
   // Build filter complex
   const filterParts: string[] = [];
@@ -453,6 +567,14 @@ export async function exportTimeline(
     overlayLabel = `[${outLabel}]`;
   });
 
+  // Drawing overlay filter entries (PNG burn-in)
+  drawingPngFiles.forEach(({ overlay, inputIdx }, i) => {
+    const outLabel = `drw${i}`;
+    const enableExpr = `between(t,${overlay.startTime},${overlay.startTime + overlay.duration})`;
+    filterParts.push(`${overlayLabel}[${inputIdx}:v]overlay=0:0:enable='${enableExpr}'[${outLabel}]`);
+    overlayLabel = `[${outLabel}]`;
+  });
+
   // Audio mixing with fades and track volume
   let audioFilterLabel = '';
   if (settings.includeAudio && audioClips.length > 0) {
@@ -561,6 +683,9 @@ export async function exportTimeline(
     // so stale files don't persist into the next export attempt.
     for (const filename of inputFiles) {
       try { await ff.deleteFile(filename); } catch { /* ignore */ }
+    }
+    for (const dpf of drawingPngFiles) {
+      try { await ff.deleteFile(dpf.filename); } catch { /* ignore */ }
     }
     try { await ff.deleteFile(fontPath); } catch { /* ignore */ }
     try { await ff.deleteFile(outputFile); } catch { /* ignore */ }

--- a/src/services/export.ts
+++ b/src/services/export.ts
@@ -4,6 +4,21 @@ import type { TimelineState } from '../store/timeline';
 import type { ExportSettings, TimelineClip } from '../types';
 import { track } from './analytics';
 
+/** Convert CSS color notation to FFmpeg color format.
+ *  FFmpeg drawtext boxcolor accepts #RRGGBB, #RRGGBBAA, and named colors,
+ *  but NOT CSS rgba() / rgb() notation. */
+function cssColorToFFmpeg(color: string): string {
+  const m = color.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)(?:\s*,\s*([\d.]+))?\s*\)/);
+  if (!m) return color; // already hex or named color — pass through
+  const r = parseInt(m[1], 10).toString(16).padStart(2, '0');
+  const g = parseInt(m[2], 10).toString(16).padStart(2, '0');
+  const b = parseInt(m[3], 10).toString(16).padStart(2, '0');
+  const a = m[4] !== undefined
+    ? Math.round(parseFloat(m[4]) * 255).toString(16).padStart(2, '0')
+    : 'ff';
+  return `#${r}${g}${b}${a}`;
+}
+
 /** Escape a string for use inside FFmpeg drawtext's text='...' option.
  *  Order matters: backslash must be escaped first. */
 function escapeDrawtext(s: string): string {
@@ -111,15 +126,27 @@ export async function exportTimeline(
   // stream. Browser-side detection (audioTracks API) is unreliable across browsers — e.g.
   // Firefox doesn't support audioTracks and we'd fall back to hasAudio=true for every file,
   // generating [N:a] filter references that crash FFmpeg when the file is video-only.
+  //
+  // Use a dedicated per-probe log listener instead of the shared ring buffer. The ring buffer
+  // approach has a race condition: log events from probing a previous file (e.g. a WAV with
+  // "Audio:") can remain queued in the JS event loop and fire after ffmpegLogs.length=0,
+  // contaminating the next probe's results and causing video-only files to be misidentified
+  // as having audio — producing [N:a] filter references that don't exist → exit code 1.
   const inputHasAudio = new Map<number, boolean>();
   for (const [mediaId, filename] of mediaFileMap) {
     const idx = inputIdxMap.get(mediaId);
     if (idx === undefined) continue;
-    ffmpegLogs.length = 0;
+    let hasAudio = false;
+    const probeHandler = ({ message }: { type: string; message: string }) => {
+      if (message.includes('Audio:')) hasAudio = true;
+    };
+    ff.on('log', probeHandler);
     await ff.exec(['-i', filename]); // exits code 1 (no output file) — we only need the log
-    inputHasAudio.set(idx, ffmpegLogs.some((l) => l.includes('Audio:')));
+    // Flush any remaining queued log events before detaching the listener
+    await new Promise<void>((r) => setTimeout(r, 0));
+    ff.off('log', probeHandler);
+    inputHasAudio.set(idx, hasAudio);
   }
-  ffmpegLogs.length = 0; // clear probe logs so only the main export logs are captured
 
   // Sort clips by track priority (higher video tracks overlay lower)
   const videoClips: (TimelineClip & { inputIdx: number })[] = [];
@@ -395,7 +422,7 @@ export async function exportTimeline(
           const escapedText = escapeDrawtext(text);
           const capLabel = `cap${captionIdx}`;
           filterParts.push(
-            `${overlayLabel}drawtext=fontfile=${fontPath}:text='${escapedText}':fontsize=${captionStyle.fontSize}:fontcolor=${captionStyle.color}:x=(w-tw)/2:y=${yPos}:enable='between(t,${start},${end})':box=1:boxcolor=${captionStyle.backgroundColor.replace(/,/g, '\\,')}:boxborderw=8[${capLabel}]`,
+            `${overlayLabel}drawtext=fontfile=${fontPath}:text='${escapedText}':fontsize=${captionStyle.fontSize}:fontcolor=${captionStyle.color}:x=(w-tw)/2:y=${yPos}:enable='between(t,${start},${end})':box=1:boxcolor=${cssColorToFFmpeg(captionStyle.backgroundColor)}:boxborderw=8[${capLabel}]`,
           );
           overlayLabel = `[${capLabel}]`;
           captionIdx++;
@@ -418,7 +445,7 @@ export async function exportTimeline(
       drawtext += `:borderw=2:bordercolor=${overlay.style.outlineColor}`;
     }
     if (overlay.style.backgroundColor !== 'transparent') {
-      drawtext += `:box=1:boxcolor=${overlay.style.backgroundColor.replace(/,/g, '\\,')}:boxborderw=6`;
+      drawtext += `:box=1:boxcolor=${cssColorToFFmpeg(overlay.style.backgroundColor)}:boxborderw=6`;
     }
 
     const outLabel = `txt${i}`;
@@ -501,39 +528,43 @@ export async function exportTimeline(
   const fcIdx = args.indexOf('-filter_complex');
   if (fcIdx >= 0) console.log('[Export] filter_complex:', args[fcIdx + 1]);
 
-  const exitCode = await ff.exec(args);
-  if (exitCode !== 0) {
-    console.error('[Export] FFmpeg failed (code', exitCode, '). Full args:', args);
-    track('export.failed', {
+  try {
+    const exitCode = await ff.exec(args);
+    if (exitCode !== 0) {
+      console.error('[Export] FFmpeg failed (code', exitCode, '). Full args:', args);
+      track('export.failed', {
+        format: settings.format,
+        quality: settings.quality,
+        exitCode,
+        filterComplex: fcIdx >= 0 ? args[fcIdx + 1] : undefined,
+        ffmpegLog: ffmpegLogs.slice(-40).join('\n'),
+      });
+      throw new Error(`FFmpeg exited with code ${exitCode}. Check browser console for details.`);
+    }
+
+    onProgress(95);
+
+    const data = await ff.readFile(outputFile);
+    const mimeType = settings.format === 'mp4' ? 'video/mp4' : 'video/webm';
+    const blob = new Blob([data as BlobPart], { type: mimeType });
+    track('export.completed', {
       format: settings.format,
       quality: settings.quality,
-      exitCode,
-      filterComplex: fcIdx >= 0 ? args[fcIdx + 1] : undefined,
-      ffmpegLog: ffmpegLogs.slice(-40).join('\n'),
+      elapsedMs: Date.now() - exportStartMs,
+      blobSizeBytes: blob.size,
     });
-    throw new Error(`FFmpeg exited with code ${exitCode}. Check browser console for details.`);
+
+    onProgress(100);
+    return blob;
+  } finally {
+    // Always clean up WASM virtual FS regardless of success or failure,
+    // so stale files don't persist into the next export attempt.
+    for (const filename of inputFiles) {
+      try { await ff.deleteFile(filename); } catch { /* ignore */ }
+    }
+    try { await ff.deleteFile(fontPath); } catch { /* ignore */ }
+    try { await ff.deleteFile(outputFile); } catch { /* ignore */ }
   }
-
-  onProgress(95);
-
-  const data = await ff.readFile(outputFile);
-  const mimeType = settings.format === 'mp4' ? 'video/mp4' : 'video/webm';
-  const blob = new Blob([data as BlobPart], { type: mimeType });
-  track('export.completed', {
-    format: settings.format,
-    quality: settings.quality,
-    elapsedMs: Date.now() - exportStartMs,
-    blobSizeBytes: blob.size,
-  });
-
-  // Cleanup
-  for (const filename of inputFiles) {
-    await ff.deleteFile(filename);
-  }
-  await ff.deleteFile(outputFile);
-
-  onProgress(100);
-  return blob;
 }
 
 export function downloadBlob(blob: Blob, filename: string) {

--- a/src/services/projects.ts
+++ b/src/services/projects.ts
@@ -40,6 +40,7 @@ export function serializeProject(state: TimelineState): Record<string, unknown> 
     tracks: state.tracks,
     clips: state.clips,
     textOverlays: state.textOverlays,
+    drawingOverlays: state.drawingOverlays,
     transcripts: state.transcripts,
     settings: {
       aspectRatio: state.settings.aspectRatio,
@@ -58,6 +59,7 @@ export function deserializeProject(
   tracks: TimelineState['tracks'];
   clips: TimelineState['clips'];
   textOverlays: TimelineState['textOverlays'];
+  drawingOverlays: TimelineState['drawingOverlays'];
   transcripts: TimelineState['transcripts'];
   settings: Partial<TimelineState['settings']>;
   mediaNameMap: Record<string, string>;
@@ -71,6 +73,7 @@ export function deserializeProject(
     tracks: (data.tracks ?? []) as TimelineState['tracks'],
     clips: (data.clips ?? {}) as TimelineState['clips'],
     textOverlays: (data.textOverlays ?? {}) as TimelineState['textOverlays'],
+    drawingOverlays: (data.drawingOverlays ?? {}) as TimelineState['drawingOverlays'],
     transcripts: (data.transcripts ?? {}) as TimelineState['transcripts'],
     settings: (data.settings ?? {}) as Partial<TimelineState['settings']>,
     mediaNameMap,

--- a/src/store/timeline.ts
+++ b/src/store/timeline.ts
@@ -910,8 +910,6 @@ export function createTimelineStore(options?: TimelineStoreOptions) {
                   const clipEnd = clip.startTime + clip.duration;
                   const regionStartInClip = region.start - clip.mediaOffset + clip.startTime;
                   const regionEndInClip = region.end - clip.mediaOffset + clip.startTime;
-                  const fillerDuration = region.end - region.start;
-
                   if (regionStartInClip > clip.startTime && regionEndInClip < clipEnd) {
                     // Interior: filler falls entirely within the clip — split and close gap.
                     // Second half starts at regionStartInClip (gap closed by removing filler duration).

--- a/src/store/timeline.ts
+++ b/src/store/timeline.ts
@@ -20,6 +20,10 @@ import type {
   AspectRatio,
   ProjectSettings,
   CaptionStyle,
+  DrawingOverlay,
+  DrawingStroke,
+  DrawingToolType,
+  DrawingTexture,
 } from '../types';
 
 const DEFAULT_CAPTION_STYLE: CaptionStyle = {
@@ -64,6 +68,15 @@ export interface TimelineState {
   selectedClipIds: string[];
   selectedTextOverlayId: string | null;
   activeTool: Tool;
+
+  // Drawing overlays
+  drawingOverlays: Record<string, DrawingOverlay>;
+  selectedDrawingOverlayId: string | null;
+  activeDrawingTool: DrawingToolType;
+  activeDrawingColor: string;
+  activeDrawingStrokeWidth: number;
+  activeDrawingTexture: DrawingTexture;
+  activeDrawingWriteOnSpeed: number;
 
   // Transcript
   transcripts: Record<string, Transcript>;
@@ -123,8 +136,21 @@ export interface TimelineState {
   removeTextOverlay: (id: string) => void;
   selectTextOverlay: (id: string | null) => void;
 
+  // Actions - Drawing Overlays
+  addDrawingOverlay: (trackId: string, startTime: number) => string;
+  updateDrawingOverlay: (id: string, updates: Partial<Pick<DrawingOverlay, 'startTime' | 'duration' | 'writeOnSpeed' | 'fadeIn' | 'fadeOut' | 'trackId'>>) => void;
+  addStrokeToDrawingOverlay: (overlayId: string, stroke: DrawingStroke) => void;
+  removeStrokeFromDrawingOverlay: (overlayId: string, strokeId: string) => void;
+  removeDrawingOverlay: (id: string) => void;
+  selectDrawingOverlay: (id: string | null) => void;
+  setActiveDrawingTool: (tool: DrawingToolType) => void;
+  setActiveDrawingColor: (color: string) => void;
+  setActiveDrawingStrokeWidth: (width: number) => void;
+  setActiveDrawingTexture: (texture: DrawingTexture) => void;
+  setActiveDrawingWriteOnSpeed: (speed: number) => void;
+
   // Actions - Tracks
-  addTrack: (type: 'video' | 'audio' | 'text') => string;
+  addTrack: (type: 'video' | 'audio' | 'text' | 'drawing') => string;
   removeTrack: (trackId: string) => void;
   toggleTrackMute: (trackId: string) => void;
   toggleTrackLock: (trackId: string) => void;
@@ -216,6 +242,7 @@ export function createTimelineStore(options?: TimelineStoreOptions) {
         tracks: options?.initialTracks ?? DEFAULT_TRACKS,
         clips: {},
         textOverlays: {},
+        drawingOverlays: {},
         playheadPosition: 0,
         isPlaying: false,
         duration: 0,
@@ -223,7 +250,13 @@ export function createTimelineStore(options?: TimelineStoreOptions) {
         snapEnabled: true,
         selectedClipIds: [],
         selectedTextOverlayId: null,
+        selectedDrawingOverlayId: null,
         activeTool: 'select' as Tool,
+        activeDrawingTool: 'pen' as DrawingToolType,
+        activeDrawingColor: '#ff0000',
+        activeDrawingStrokeWidth: 4,
+        activeDrawingTexture: 'solid' as DrawingTexture,
+        activeDrawingWriteOnSpeed: 1,
         transcripts: {},
         activeTranscriptMediaId: null,
         settings: { ...DEFAULT_SETTINGS, ...options?.initialSettings },
@@ -640,11 +673,82 @@ export function createTimelineStore(options?: TimelineStoreOptions) {
             if (id) state.selectedClipIds = [];
           }),
 
+        // Drawing Overlays
+        addDrawingOverlay: (trackId, startTime) => {
+          const id = uuid();
+          set((state) => {
+            state.drawingOverlays[id] = {
+              id,
+              trackId,
+              startTime,
+              duration: 5,
+              strokes: [],
+              writeOnSpeed: 1,
+            };
+          });
+          get().recalculateDuration();
+          return id;
+        },
+
+        updateDrawingOverlay: (id, updates) =>
+          set((state) => {
+            const overlay = state.drawingOverlays[id];
+            if (!overlay) return;
+            if (updates.startTime !== undefined) overlay.startTime = updates.startTime;
+            if (updates.duration !== undefined) overlay.duration = updates.duration;
+            if (updates.writeOnSpeed !== undefined) overlay.writeOnSpeed = updates.writeOnSpeed;
+            if (updates.fadeIn !== undefined) overlay.fadeIn = updates.fadeIn;
+            if (updates.fadeOut !== undefined) overlay.fadeOut = updates.fadeOut;
+            if (updates.trackId !== undefined) overlay.trackId = updates.trackId;
+          }),
+
+        addStrokeToDrawingOverlay: (overlayId, stroke) =>
+          set((state) => {
+            const overlay = state.drawingOverlays[overlayId];
+            if (overlay) overlay.strokes.push(stroke);
+          }),
+
+        removeStrokeFromDrawingOverlay: (overlayId, strokeId) =>
+          set((state) => {
+            const overlay = state.drawingOverlays[overlayId];
+            if (overlay) overlay.strokes = overlay.strokes.filter((s) => s.id !== strokeId);
+          }),
+
+        removeDrawingOverlay: (id) =>
+          set((state) => {
+            delete state.drawingOverlays[id];
+            if (state.selectedDrawingOverlayId === id) state.selectedDrawingOverlayId = null;
+          }),
+
+        selectDrawingOverlay: (id) =>
+          set((state) => {
+            state.selectedDrawingOverlayId = id;
+            if (id) {
+              state.selectedClipIds = [];
+              state.selectedTextOverlayId = null;
+            }
+          }),
+
+        setActiveDrawingTool: (tool) =>
+          set((state) => { state.activeDrawingTool = tool; }),
+
+        setActiveDrawingColor: (color) =>
+          set((state) => { state.activeDrawingColor = color; }),
+
+        setActiveDrawingStrokeWidth: (width) =>
+          set((state) => { state.activeDrawingStrokeWidth = width; }),
+
+        setActiveDrawingTexture: (texture) =>
+          set((state) => { state.activeDrawingTexture = texture; }),
+
+        setActiveDrawingWriteOnSpeed: (speed) =>
+          set((state) => { state.activeDrawingWriteOnSpeed = speed; }),
+
         addTrack: (type) => {
           const trackId = uuid();
           set((state) => {
             const trackNum = state.tracks.filter((t) => t.type === type).length + 1;
-            const prefix = type === 'video' ? 'V' : type === 'audio' ? 'A' : 'T';
+            const prefix = type === 'video' ? 'V' : type === 'audio' ? 'A' : type === 'drawing' ? 'D' : 'T';
             const track: Track = {
               id: trackId,
               type,
@@ -674,6 +778,11 @@ export function createTimelineStore(options?: TimelineStoreOptions) {
             Object.keys(state.textOverlays).forEach((id) => {
               if (state.textOverlays[id].trackId === trackId) {
                 delete state.textOverlays[id];
+              }
+            });
+            Object.keys(state.drawingOverlays).forEach((id) => {
+              if (state.drawingOverlays[id].trackId === trackId) {
+                delete state.drawingOverlays[id];
               }
             });
           });
@@ -804,13 +913,14 @@ export function createTimelineStore(options?: TimelineStoreOptions) {
                   const fillerDuration = region.end - region.start;
 
                   if (regionStartInClip > clip.startTime && regionEndInClip < clipEnd) {
-                    // Interior: filler falls entirely within the clip — split and close gap
+                    // Interior: filler falls entirely within the clip — split and close gap.
+                    // Second half starts at regionStartInClip (gap closed by removing filler duration).
                     const newClipId = uuid();
                     state.clips[newClipId] = {
                       id: newClipId,
                       mediaFileId: clip.mediaFileId,
                       trackId: clip.trackId,
-                      startTime: regionStartInClip - fillerDuration,
+                      startTime: regionStartInClip,
                       duration: clipEnd - regionEndInClip,
                       mediaOffset: clip.mediaOffset + (regionEndInClip - clip.startTime),
                       name: clip.name,
@@ -1066,6 +1176,10 @@ export function createTimelineStore(options?: TimelineStoreOptions) {
             points.push(overlay.startTime);
             points.push(overlay.startTime + overlay.duration);
           });
+          Object.values(state.drawingOverlays).forEach((overlay) => {
+            points.push(overlay.startTime);
+            points.push(overlay.startTime + overlay.duration);
+          });
           // Scene boundaries
           Object.values(state.transcripts).forEach((t) => {
             t.scenes.forEach((s) => {
@@ -1085,6 +1199,9 @@ export function createTimelineStore(options?: TimelineStoreOptions) {
             Object.values(state.textOverlays).forEach((overlay) => {
               maxEnd = Math.max(maxEnd, overlay.startTime + overlay.duration);
             });
+            Object.values(state.drawingOverlays).forEach((overlay) => {
+              maxEnd = Math.max(maxEnd, overlay.startTime + overlay.duration);
+            });
             state.duration = maxEnd + 5;
           }),
       })),
@@ -1093,6 +1210,7 @@ export function createTimelineStore(options?: TimelineStoreOptions) {
           tracks: state.tracks,
           clips: state.clips,
           textOverlays: state.textOverlays,
+          drawingOverlays: state.drawingOverlays,
           transcripts: state.transcripts,
           mediaFiles: state.mediaFiles,
           settings: state.settings,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -76,7 +76,7 @@ export interface Transition {
 
 export interface Track {
   id: string;
-  type: 'video' | 'audio' | 'text';
+  type: 'video' | 'audio' | 'text' | 'drawing';
   name: string;
   muted: boolean;
   locked: boolean;
@@ -110,6 +110,45 @@ export interface TextStyle {
   textAlign: 'left' | 'center' | 'right';
   outline: boolean;
   outlineColor: string;
+}
+
+export type DrawingToolType = 'pen' | 'arrow' | 'circle' | 'rectangle';
+
+export type DrawingTexture = 'solid' | 'marker' | 'chalk';
+
+export interface DrawingPoint {
+  x: number; // normalized 0–1 (relative to canvas width)
+  y: number; // normalized 0–1 (relative to canvas height)
+}
+
+/** A single drawn stroke or shape.
+ *  points interpretation by tool:
+ *   pen:       polyline — all captured pointer positions
+ *   arrow:     exactly 2 points [start, end]
+ *   circle:    exactly 2 points [center, edge] — radius = distance
+ *   rectangle: exactly 2 points [topLeft, bottomRight]
+ */
+export interface DrawingStroke {
+  id: string;
+  tool: DrawingToolType;
+  texture: DrawingTexture;
+  color: string;         // CSS hex e.g. '#ff0000'
+  strokeWidth: number;   // pixels at 1920px canvas width; scale proportionally
+  opacity: number;       // baked in at creation: solid=1, marker=0.5, chalk=0.7
+  points: DrawingPoint[];
+}
+
+/** A timed drawing layer — mirrors TextOverlay structurally */
+export interface DrawingOverlay {
+  id: string;
+  trackId: string;
+  startTime: number;
+  duration: number;
+  strokes: DrawingStroke[];
+  /** Write-on animation speed multiplier: 0.5=slow, 1=normal, 2=fast (preview-only in v1) */
+  writeOnSpeed: number;
+  fadeIn?: number;
+  fadeOut?: number;
 }
 
 export interface CaptionStyle {
@@ -174,7 +213,7 @@ export interface Transcript {
   scenes: Scene[];
 }
 
-export type Tool = 'select' | 'razor' | 'trim' | 'text';
+export type Tool = 'select' | 'razor' | 'trim' | 'text' | 'draw';
 
 export type FillerRemovalMode = 'delete' | 'gap' | 'ignore' | 'transcript-only';
 


### PR DESCRIPTION
## Summary
- Add DaVinci Resolve-style drawing annotation layer over video, for tutorial arrows/circles/highlights
- 4 tools: **pen**, **arrow**, **circle**, **rectangle** (press `D` or click toolbar button)
- 3 textures: solid, marker (50% alpha, square cap), chalk (3-pass effect)
- Write-on animation: strokes reveal progressively during playback (speed 0.5×–2×, per-overlay)
- Drawing track type with sky-blue color; '+ Drawing' button in timeline; DrawingToolPanel in settings sidebar
- Export: `OffscreenCanvas` → PNG → FFmpeg `overlay` filter (static burn-in at export time)
- Full save/load: `drawingOverlays` serialized in project JSON and auto-save

## Test plan
- [ ] Press `D` or click Pen icon in toolbar — tool activates, DrawingToolPanel appears in settings
- [ ] Add a drawing track via '+ Drawing' button in timeline
- [ ] Draw a freehand stroke on the viewer — stroke appears in real time; clip appears on drawing track
- [ ] Switch tools (arrow, circle, rectangle), change color/width/texture — new strokes reflect settings
- [ ] Play back — strokes reveal progressively (write-on animation)
- [ ] Export video — drawing overlays are burned in as static PNGs
- [ ] Reload page — drawing overlays restore from auto-save

🤖 Generated with [Claude Code](https://claude.com/claude-code)